### PR TITLE
Add Jetson Orin Nano Support with GPU Acceleration

### DIFF
--- a/Dockerfile.jetson
+++ b/Dockerfile.jetson
@@ -1,0 +1,44 @@
+# Use the official NVIDIA Jetson PyTorch base for JetPack 6.x (L4T 36.x)
+# This includes the correct CUDA/cuDNN/PyTorch binaries for CC 8.7
+# Use the official NVIDIA Jetson PyTorch base for JetPack 6
+FROM dustynv/l4t-pytorch:r36.2.0
+
+LABEL maintainer="Wanghley Soares Martins"
+LABEL description="Wyoming Voice Match - Jetson Orin Nano Adaptation"
+
+WORKDIR /app
+
+# Install system dependencies for audio and building
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libsndfile1 \
+    ffmpeg \
+    libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy only the requirements first to leverage Docker cache
+COPY requirements.txt .
+
+# Install dependencies using the Jetson AI Lab index for ARM64 compatibility
+RUN pip3 install --no-cache-dir \
+    --index-url https://pypi.org/simple \
+    --extra-index-url https://pypi.jetson-ai-lab.io/jp6/cu126 \
+    -r requirements.txt \
+    "numpy<2" \
+    "speechbrain"
+
+# Copy the application source code
+COPY wyoming_voice_match/ wyoming_voice_match/
+COPY scripts/ scripts/
+
+# Patch SpeechBrain's torchaudio backend check for modern torchaudio compatibility
+RUN if [ -f /usr/local/lib/python3.10/dist-packages/speechbrain/utils/torch_audio_backend.py ]; then \
+        sed -i 's/available_backends = torchaudio.list_audio_backends()/available_backends = []/' \
+            /usr/local/lib/python3.10/dist-packages/speechbrain/utils/torch_audio_backend.py; \
+    fi
+
+# Create data structures
+RUN mkdir -p /data/enrollment /data/voiceprints /data/models
+
+EXPOSE 10350
+
+ENTRYPOINT ["python3", "-m", "wyoming_voice_match"]

--- a/Dockerfile.jetson
+++ b/Dockerfile.jetson
@@ -3,8 +3,8 @@
 # Use the official NVIDIA Jetson PyTorch base for JetPack 6
 FROM dustynv/l4t-pytorch:r36.2.0
 
-LABEL maintainer="Wanghley Soares Martins"
-LABEL description="Wyoming Voice Match - Jetson Orin Nano Adaptation"
+LABEL maintainer="Wyoming Voice Match"
+LABEL description="Wyoming ASR proxy with ECAPA-TDNN speaker verification"
 
 WORKDIR /app
 


### PR DESCRIPTION
### Description

This PR introduces a dedicated Docker environment for **NVIDIA Jetson Orin Nano** (and other JetPack 6.x devices). It ensures that the Wyoming Voice Match service can leverage the integrated Maxwell/Ampere GPU for inference, significantly improving performance on edge hardware.

The primary addition is `DockerFile.jetson`, which is specifically architected to handle the unique ARM64/CUDA requirements of the Jetson platform.

### Changes

* **New Base Image:** Migrated to `dustynv/l4t-pytorch:r36.2.0` to ensure compatibility with **JetPack 6.x (L4T 36.x)**.
* **Dependency Management:** * Implemented `pypi.jetson-ai-lab.io` as an extra index to pull ARM64-optimized wheels.
* Pinned `numpy < 2` and included `speechbrain` with a custom patch.


* **SpeechBrain Compatibility:** Added a `sed` patch to bypass `torchaudio` backend checks that often fail in specialized Jetson environments, ensuring stable audio processing.
* **Optimized Build:** Standardized system dependencies (`libsndfile1`, `ffmpeg`) and created necessary directory structures for persistence.

### Deployment Recommendation

For full hardware acceleration, I would recommend to build and run the image with the following tag:
`wyoming-voice-match:jetson-gpu`

This ensures users can easily identify the build intended for GPU-passthrough capabilities on NVIDIA edge boards.