### PR TITLE
Pascal (cu121) support

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -98,6 +98,50 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
+  build-pascal-gpu:
+    name: Build Pascal GPU Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}},suffix=-pascal-gpu
+            type=semver,pattern={{major}}.{{minor}},suffix=-pascal-gpu
+            type=raw,value=pascal-gpu
+
+      - name: Build and push Pascal GPU image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.pascal
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
   build-jetson-gpu:
     name: Build Jetson GPU Image
     runs-on: ubuntu-latest

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -42,11 +42,13 @@ wyoming-voice-match/
 │   └── test_verify.py            # Threshold tuning CLI
 ├── tools/
 │   └── record_samples.ps1        # Windows PowerShell recording helper
-├── Dockerfile                    # GPU image (CUDA 12.4 + cuDNN, multi-stage)
+├── Dockerfile                    # GPU image (CUDA 12.8 + cuDNN, multi-stage)
+├── Dockerfile.pascal             # Pascal GPU image (CUDA 12.1 + cuDNN, multi-stage)
 ├── Dockerfile.cpu                # CPU image (python:3.11-slim)
 ├── docker-compose.yml            # GPU compose config
+├── docker-compose.pascal.yml     # Pascal GPU compose config
 ├── docker-compose.cpu.yml        # CPU compose config
-├── requirements.txt              # GPU Python deps (torch installed separately via cu121 index)
+├── requirements.txt              # GPU Python deps (torch installed separately in Dockerfiles)
 ├── requirements.cpu.txt          # CPU Python deps (torch from default PyPI)
 ├── LICENSE                       # MIT
 ├── README.md                     # User-facing documentation
@@ -65,7 +67,7 @@ The solution has two parts:
 
 ### Python Packages
 
-**requirements.txt** (GPU - torch/torchaudio installed separately from `https://download.pytorch.org/whl/cu121`):
+**requirements.txt** (GPU - torch/torchaudio installed separately in Dockerfiles):
 ```
 wyoming==1.8.0
 speechbrain>=1.0.0
@@ -506,9 +508,9 @@ Debug logging is always enabled so the output shows the complete region-by-regio
 
 Multi-stage build to minimize image size (~5GB):
 
-**Stage 1 (builder):** `nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04`
+**Stage 1 (builder):** `nvidia/cuda:12.8.1-cudnn-runtime-ubuntu22.04`
 - Installs python3, python3-pip, python3-dev, libsndfile1
-- Installs torch and torchaudio from `https://download.pytorch.org/whl/cu121`
+- Installs torch and torchaudio from `https://download.pytorch.org/whl/cu128`
 - Installs remaining requirements from requirements.txt
 - Cleanup step removes ~2GB of redundant files:
   - Triton (~600MB, not needed for inference)
@@ -519,12 +521,26 @@ Multi-stage build to minimize image size (~5GB):
   - SpeechBrain recipes and tests directories
   - All `__pycache__` directories
 
-**Stage 2 (runtime):** `nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04`
+**Stage 2 (runtime):** `nvidia/cuda:12.8.1-cudnn-runtime-ubuntu22.04`
 - Installs python3, libsndfile1, ffmpeg, libgomp1
 - Copies installed Python packages from builder
 - Copies application code (wyoming_voice_match/ and scripts/)
 - Creates /data directory structure (enrollment, voiceprints, models)
 - Entrypoint: `python -m wyoming_voice_match`
+
+### Pascal GPU Image (Dockerfile.pascal)
+
+Multi-stage build for Pascal-era NVIDIA GPUs such as GTX 10xx, Quadro P, and Tesla P cards:
+
+**Stage 1 (builder):** `nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04`
+- Installs python3, python3-pip, python3-dev, libsndfile1
+- Pins `torch==2.5.1` and `torchaudio==2.5.1` from `https://download.pytorch.org/whl/cu121`
+- Installs remaining requirements from requirements.txt
+- Uses the same cleanup pattern as the default GPU image
+
+**Stage 2 (runtime):** `nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04`
+- Same runtime packages, application code, /data directory structure, and entrypoint as the default GPU image
+- Published as `ghcr.io/jxlarrea/wyoming-voice-match:pascal-gpu`
 
 ### CPU Image (Dockerfile.cpu)
 
@@ -901,7 +917,7 @@ See scripts/enroll_record.py source in the main project. The complete file is in
 ### Dockerfile
 
 ```dockerfile
-FROM nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04 AS builder
+FROM nvidia/cuda:12.8.1-cudnn-runtime-ubuntu22.04 AS builder
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -914,7 +930,7 @@ RUN apt-get update && \
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir \
-        torch torchaudio --index-url https://download.pytorch.org/whl/cu121 && \
+        torch torchaudio --index-url https://download.pytorch.org/whl/cu128 && \
     pip install --no-cache-dir -r requirements.txt && \
     pip uninstall -y triton 2>/dev/null; \
     rm -rf /usr/local/lib/python3.10/dist-packages/nvidia/cublas && \
@@ -939,7 +955,7 @@ RUN pip install --no-cache-dir \
     find /usr/local/lib/python3.10/dist-packages -name "__pycache__" -type d -exec rm -rf {} + 2>/dev/null; \
     echo "Cleanup complete"
 
-FROM nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04
+FROM nvidia/cuda:12.8.1-cudnn-runtime-ubuntu22.04
 
 LABEL maintainer="Wyoming Voice Match"
 LABEL description="Wyoming ASR proxy with ECAPA-TDNN speaker verification"

--- a/Dockerfile.pascal
+++ b/Dockerfile.pascal
@@ -1,0 +1,83 @@
+FROM nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04 AS builder
+
+RUN apt-get update -o Acquire::AllowInsecureRepositories=true && \
+    apt-get install -y --allow-unauthenticated --no-install-recommends \
+        ca-certificates \
+        python3 \
+        python3-pip \
+        python3-dev \
+        libsndfile1 && \
+    ln -sf /usr/bin/python3 /usr/bin/python && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+
+RUN pip install --no-cache-dir torch==2.5.1 torchaudio==2.5.1 --index-url https://download.pytorch.org/whl/cu121 && \
+    pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir numpy && \
+    pip uninstall -y triton 2>/dev/null; \
+    echo "=== DEBUG: pip list ===" && pip list && \
+    echo "=== DEBUG: python path ===" && python -c "import site; print(site.getsitepackages())" && \
+    rm -rf /usr/local/lib/python3.10/dist-packages/nvidia/cublas && \
+    rm -rf /usr/local/lib/python3.10/dist-packages/nvidia/cuda_runtime && \
+    rm -rf /usr/local/lib/python3.10/dist-packages/nvidia/cuda_nvrtc && \
+    echo "Keeping cuDNN from the PyTorch wheel (CUDA 12.1 base includes cuDNN 8)" && \
+    rm -rf /usr/local/lib/python3.10/dist-packages/nvidia/cufft && \
+    rm -rf /usr/local/lib/python3.10/dist-packages/nvidia/curand && \
+    rm -rf /usr/local/lib/python3.10/dist-packages/nvidia/cusolver && \
+    rm -rf /usr/local/lib/python3.10/dist-packages/nvidia/cusparse && \
+    echo "Keeping NCCL (required by libtorch_cuda.so)" && \
+    rm -rf /usr/local/lib/python3.10/dist-packages/nvidia/nvjitlink && \
+    cd /usr/local/lib/python3.10/dist-packages/torch/lib && \
+    rm -f libcublas* libcublasLt* libcusolver* \
+          libcufft* libcurand* libnvrtc* libnvJitLink* libnvfuser*; \
+    find /usr/local/lib/python3.10/dist-packages/torch -name "*.a" -delete && \
+    rm -rf /usr/local/lib/python3.10/dist-packages/torch/include && \
+    rm -rf /usr/local/lib/python3.10/dist-packages/torch/share && \
+    pip uninstall -y sympy networkx 2>/dev/null; \
+    rm -rf /usr/local/lib/python3.10/dist-packages/speechbrain/recipes && \
+    rm -rf /usr/local/lib/python3.10/dist-packages/speechbrain/tests && \
+    find /usr/local/lib/python3.10/dist-packages -name "__pycache__" -type d -exec rm -rf {} + 2>/dev/null; \
+    echo "Cleanup complete"
+
+# --- Runtime stage ---
+FROM nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04
+
+LABEL maintainer="Wyoming Voice Match"
+LABEL description="Wyoming ASR proxy with ECAPA-TDNN speaker verification (Pascal GPU)"
+
+WORKDIR /app
+
+RUN dpkg --configure -a && \
+    apt-get update -o Acquire::AllowInsecureRepositories=true && \
+    apt-get install -y --allow-unauthenticated --no-install-recommends \
+        python3 \
+        libsndfile1 \
+        ffmpeg \
+        libavcodec58 \
+        libavformat58 \
+        libavutil56 \
+        libswresample3 \
+        libgomp1 && \
+    ln -sf /usr/bin/python3 /usr/bin/python && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/local/lib/python3.10/dist-packages /usr/local/lib/python3.10/dist-packages
+COPY --from=builder /usr/local/bin /usr/local/bin
+
+RUN ls /usr/local/lib/python3.10/dist-packages/ | grep -i numpy || echo "NO NUMPY FOUND"
+
+COPY wyoming_voice_match/ wyoming_voice_match/
+COPY scripts/ scripts/
+
+# Patch SpeechBrain's torchaudio backend check (list_audio_backends removed in newer torchaudio)
+RUN if [ -f /usr/local/lib/python3.10/dist-packages/speechbrain/utils/torch_audio_backend.py ]; then \
+        sed -i 's/available_backends = torchaudio.list_audio_backends()/available_backends = []/' \
+            /usr/local/lib/python3.10/dist-packages/speechbrain/utils/torch_audio_backend.py; \
+    fi
+
+RUN mkdir -p /data/enrollment /data/voiceprints /data/models
+
+EXPOSE 10350
+ENTRYPOINT ["python", "-m", "wyoming_voice_match"]

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ flowchart LR
 
 A running Wyoming-compatible ASR service such as [wyoming-faster-whisper](https://github.com/rhasspy/wyoming-faster-whisper) or [wyoming-onnx-asr](https://github.com/tboby/wyoming-onnx-asr). Wyoming Voice Match sits in front of this service as a proxy and forwards verified, cleaned audio to it.
 
-The Quick Start guide below uses Docker and Docker Compose for deployment. An NVIDIA GPU is recommended for fast inference (~5-25ms verification) but not required — CPU inference works at ~200-500ms. The scripts can also be run directly with Python 3.10+ and the dependencies listed in `requirements.txt`.
+The Quick Start guide below uses Docker and Docker Compose for deployment. An NVIDIA GPU is recommended for fast inference (~5-25ms verification) but not required — CPU inference works at ~200-500ms. Use the `pascal-gpu` image for Pascal-era NVIDIA GPUs such as GTX 10xx cards. The scripts can also be run directly with Python 3.10+ and the dependencies listed in `requirements.txt`.
 
 ## Quick Start
 
@@ -138,6 +138,34 @@ mkdir -p data/enrollment
 services:
   wyoming-voice-match:
     image: ghcr.io/jxlarrea/wyoming-voice-match:latest
+    container_name: wyoming-voice-match
+    restart: unless-stopped
+    ports:
+      - "10350:10350"
+    volumes:
+      - ./data:/data
+    environment:
+      - UPSTREAM_URI=tcp://wyoming-faster-whisper:10300
+      - LISTEN_URI=tcp://0.0.0.0:10350
+      - VERIFY_THRESHOLD=0.30
+      - EXTRACTION_THRESHOLD=0.25
+      - HF_HOME=/data/hf_cache
+      - LOG_LEVEL=DEBUG
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+```
+
+**Pascal GPU (GTX 10xx / Quadro P / Tesla P):**
+
+```yaml
+services:
+  wyoming-voice-match:
+    image: ghcr.io/jxlarrea/wyoming-voice-match:pascal-gpu
     container_name: wyoming-voice-match
     restart: unless-stopped
     ports:

--- a/docker-compose.pascal.yml
+++ b/docker-compose.pascal.yml
@@ -1,0 +1,29 @@
+services:
+  wyoming-voice-match:
+    image: ghcr.io/jxlarrea/wyoming-voice-match:pascal-gpu
+    container_name: wyoming-voice-match
+    restart: unless-stopped
+    ports:
+      - "10350:10350"
+    volumes:
+      - ./data:/data
+    environment:
+      - UPSTREAM_URI=tcp://wyoming-faster-whisper:10300
+      - LISTEN_URI=tcp://0.0.0.0:10350
+      - VERIFY_THRESHOLD=0.30
+      - EXTRACTION_THRESHOLD=0.25
+      - LOG_LEVEL=DEBUG
+      - HF_HOME=/data/hf_cache
+      # - REQUIRE_SPEAKER_MATCH=true       # Set to false to forward unmatched audio
+      # - TAG_SPEAKER=false                # Prepend [speaker_name] to transcripts
+      # - MAX_VERIFY_SECONDS=5.0           # First-pass verification window
+      # - VERIFY_WINDOW_SECONDS=3.0        # Sliding window size for fallback pass
+      # - VERIFY_STEP_SECONDS=1.5          # Sliding window step size
+      # - SAVE_REJECTED=false              # Save rejected audio to /data/rejections
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]


### PR DESCRIPTION
Hey, I wanted a build that supports my older (1070) Pascal card.

I put nearly zero effort into this, I just instructed codex to do it for me, though I did test it and read though the diff to make sure it looked sane.

Adds a new Pascal-compatible GPU container build for older NVIDIA cards such as the GTX 1070.

  Changes include:

  - New Dockerfile.pascal using CUDA 12.1 with PyTorch/torchaudio 2.5.1+cu121
  - New docker-compose.pascal.yml using the pascal-gpu image tag
  - Additive GitHub Actions job to publish pascal-gpu images for linux/amd64
  - README/DESIGN updates documenting when to use the Pascal image
  - Fixes an existing indentation error in handler.py that prevented container startup

  Validated locally on a GTX 1070 with CUDA available inside the container.

Like your own documentation I saw performance go from ~500ms on CPU down to around ~30ms on my GTX 1070 with this image.

No pressure to merge - I pushed this just in case it is useful to others.